### PR TITLE
Pin to jspdf version rather than getting the (possibly inconsistent) master version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ npm install
 And then...
 
 ```
+var jsPDF = require('node-jspdf');
+
 var doc = jsPDF();
 doc.text(20, 20, 'Hello, world.');
 doc.save('Test.pdf', function(err){console.log('saved!');});

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@ if [ ! -d vendor/jsPDF ]; then
     wget --no-check-certificate -O jsPDF.zip https://github.com/MrRio/jsPDF/archive/v1.2.61.zip
     unzip jsPDF.zip
     mkdir vendor
-    mv jsPDF-master vendor/jsPDF
+    mv jsPDF-* vendor/jsPDF
     rm jsPDF.zip
 fi

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 if [ ! -d vendor/jsPDF ]; then
-    wget --no-check-certificate -O jsPDF.zip https://github.com/MrRio/jsPDF/archive/master.zip
+    wget --no-check-certificate -O jsPDF.zip https://github.com/MrRio/jsPDF/archive/v1.2.61.zip
     unzip jsPDF.zip
     mkdir vendor
     mv jsPDF-master vendor/jsPDF


### PR DESCRIPTION
The current node-jspdf from npm doesn't work, because that version of the node-jspdf code is not compatible with the master version of jspdf that it fetches.  The github repo for node-jspdf has been updated to match the current version of jspdf, but that update hasn't yet made it to npm.

This change pins the fetched version of jspf to a known compatible version (the current 1.2.61 version).  Once this makes it to npm, the node-jspdf installed by npm will work and continue to work even if there is a newer, incompatible jspdf version.  Whenever there is a jspdf change that seems important enough to cause an update in node-jspdf, the compatibility should be checked, any necessary changes should be made, and the version number embedded in install.sh should be changed.

Without this, the current situation could recur where 'npm install node-jpdfs' gets a broken node-jspdf.

I also added a sample 'require' line to the readme.
